### PR TITLE
file-lock: Add better IPC support

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ This will create lock file with extension ".lock" in the same directory. Example
 
 Last parameter is optional and defines if lock should be automatically refreshing before expired.
 
-If file already has lock file, and it time haven't expired, method returns null.
+If file already has lock file, and it time haven't expired, method returns false.
 
 ## Recommended using ##
 

--- a/Xabe.FileLock.Test/FileLockTests.cs
+++ b/Xabe.FileLock.Test/FileLockTests.cs
@@ -129,5 +129,24 @@ namespace Xabe.FileLock.Test
             var fileDate = new DateTime(long.Parse(File.ReadAllText(Path.ChangeExtension(file.FullName, Extension))));
             Assert.True(fileDate - DateTime.UtcNow - TimeSpan.FromHours(2) < _timeVariable);
         }
+
+        [Fact]
+        public async void GetTimeReturnsMaxValueWithNoLock()
+        {
+            var file = new FileInfo(Path.GetTempFileName());
+            var fileLock = new FileLock(file);
+            DateTime dateTime = await fileLock.GetReleaseDate();
+            Assert.Equal(DateTime.MaxValue, dateTime);
+        }
+
+        [Fact]
+        public async void GetTimeReturnsCurrentReleaseDate()
+        {
+            var file = new FileInfo(Path.GetTempFileName());
+            var fileLock = new FileLock(file);
+            await fileLock.TryAcquire(TimeSpan.FromHours(1));
+            DateTime dateTime = await fileLock.GetReleaseDate();
+            Assert.NotEqual(DateTime.MaxValue, dateTime);
+        }
     }
 }

--- a/Xabe.FileLock/FileLock.cs
+++ b/Xabe.FileLock/FileLock.cs
@@ -56,6 +56,15 @@ namespace Xabe.FileLock
             await _content.TrySetReleaseDate(await _content.GetReleaseDate() + lockTime);
         }
 
+        /// <summary>
+        ///     Get current lock release date
+        /// </summary>
+        /// <returns>Estimated date when lock gets released. DateTime.MaxValue if no lock exists.</returns>
+        public async Task<DateTime> GetReleaseDate()
+        {
+          return await _content.GetReleaseDate();
+        }
+
         /// <inheritdoc />
         public async Task<bool> TryAcquire(DateTime releaseDate)
         {

--- a/Xabe.FileLock/ILock.cs
+++ b/Xabe.FileLock/ILock.cs
@@ -15,6 +15,12 @@ namespace Xabe.FileLock
         Task AddTime(TimeSpan lockTime);
 
         /// <summary>
+        ///     Get current lock release date
+        /// </summary>
+        /// <returns>Estimated date when lock gets released. DateTime.MaxValue if no lock exists.</returns>
+        Task<DateTime> GetReleaseDate();
+
+        /// <summary>
         ///     Acquire lock.
         /// </summary>
         /// <param name="releaseDate">Date after that lock is released</param>


### PR DESCRIPTION
In the case multiple processes are using the lock file the new `GetReleaseDate` method on the `ILock` interface will help the other processes to better act upon the current lock.  The release date retrival will give them a change to do something other in the mean time or they can use a retry policy that will wait until the estimated release date arises and then they will try again.


